### PR TITLE
Simplify `$anonymousPattern` further

### DIFF
--- a/index.php
+++ b/index.php
@@ -66,8 +66,7 @@ checkbox( 'sitelinks', 'Sitelink removals', isset( $_REQUEST['sitelinks'] ) );
 <?php
 
 function userlink( $username ) {
-	$anonymousPattern = '/^~2.+$/i';
-	if ( preg_match( $anonymousPattern, $username ) ) {
+	if ( str_starts_with( $username, '~2' ) ) {
 		$page = "Special:Contributions/{$username}";
 	} else {
 		$username = strtr( $username, ' ', '_' );

--- a/service.template
+++ b/service.template
@@ -1,5 +1,3 @@
 # Toolforge webservice template
 # Provide default arguments for `webservice start` commands for this tool.
-backend: kubernetes
-type: php7.3
-canonical: True
+type: php8.4


### PR DESCRIPTION
No need to match the rest of the string, or for the regex to be case-insensitive now that it doesn’t contain letters anymore.

Once we’re on PHP 8.0+, we can even use `str_starts_with()` (but currently we still seem to be running on PHP 7.3 AFAICT).